### PR TITLE
fish configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zsh.yazi
 
-A yazi plugin to open zsh as your default Shell.
+A yazi plugin to open zsh(or any other) as your default Shell.
 
 ## Previews
 https://github.com/AnirudhG07/zsh.yazi/assets/146579014/4f194afe-c7bd-4c43-b361-348319d1b22d
@@ -11,7 +11,7 @@ This code is written by the maintainer of sxyazi/yazi, and was given as solution
 
 ## Requirements
 
-Yazi version 0.2.5 or higher. And of course, zsh shell.
+Yazi version 0.2.5 or higher. And of course, zsh(or any other) shell as your default.
 
 ## Installation
 
@@ -27,16 +27,28 @@ Windows user's should check the init.lua file to make sure the paths used are co
 
 ## Usage
 
+### Keymapping
 Add this to your `keymap.toml` file:
 
+For zsh:
 ```toml
 [[manager.prepend_keymap]]
 on = [ ":" ]
 run = "plugin zsh"
 desc = "Zsh shell"
 ```
+For fish:
+```toml
+[[manager.prepend_keymap]]
+on = [ ":" ]
+run = "plugin fish"
+desc = "Fish <°))>< shell"
+```
+
+### Shell changes
+If you are using some other shell apart from, like fish, please change the directory name to `shell.yazi`. OR you can just change the keymapping description keeping `run = "plugin zsh"` as it is.
 
 ## Features
 
-- Open zsh as your default shell.
+- Open zsh(or any other) as your default shell.
 - Usage of aliases is supported.

--- a/init.lua
+++ b/init.lua
@@ -2,11 +2,13 @@ return {
 	entry = function()
 		local value, event = ya.input({
 			title = "Zsh shell:",
+			-- title = "Fish <º))>< shell:",
 			position = { "top-center", y = 3, w = 40 },
 		})
 		if event == 1 then
 			ya.manager_emit("shell", {
 				"zsh -ic 'source ~/.zshrc; " .. ya.quote(value .. "; exit'", true),
+				-- "fish -c " .. ya.quote(value .. "; exit", true),
 				block = true,
 				confirm = true,
 			})


### PR DESCRIPTION
Adding fish confiugurations in zsh.yazi to minimise plugin number. You can simply comment off the shell you dont want to use in `init.lua`, change some keymappings and you are done.