### PR TITLE
fix zsh: suspended

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,7 @@ local function shell_choice(shell_val)
 	}
 
 	local shell_map = {
-		bash = { shell_val = "bash", supporter = "-c" },
+		bash = { shell_val = "bash", supporter = "-ic" },
 		zsh = { shell_val = "zsh", supporter = "-ic" },
 		fish = { shell_val = "fish", supporter = "-c" },
 		pwsh = { shell_val = "pwsh", supporter = "-Command" },
@@ -78,7 +78,7 @@ local function entry(_, args)
 
 	if event == 1 then
 		ya.manager_emit("shell", {
-			shell_val .. " " .. supp .. " " .. ya.quote(cmd, true),
+			shell_val .. " " .. supp .. " " .. ya.quote(cmd .. "; exit", true),
 			block = block,
 			confirm = confirm,
 			orphan = orphan,


### PR DESCRIPTION
‌‌‌‌‌‌In fact, it runs `custom_shell -it "command"; exit`, which you have already mentioned in the [README](https://github.com/AnirudhG07/custom-shell.yazi/blob/main/README.md?plain=1#L50). 

However, I did not see the `; exit` operation in the code, which causes the interactive shell of `zsh -it` to not exit correctly (https://github.com/AnirudhG07/custom-shell.yazi/issues/5). 

After testing, these changes allow me to run the default terminal environments of `bash` or `zsh` normally (with aliases and environment variables working properly). 

Note that I only tested `bash` and `zsh`; I'm not sure about others.