### PR TITLE
Fix quoting in shell arg

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -184,7 +184,7 @@ local function entry(_, job)
 	if event == 1 then
 		local after_cmd = separator .. (wait and wait_cmd or "exit")
 		-- for history also, this will be added.
-		custom_shell_cmd = shell_val .. " " .. supp .. " " .. ya.quote(cmd .. after_cmd, true)
+		custom_shell_cmd = shell_val .. " " .. supp .. " " .. ya.quote(cmd .. after_cmd)
 
 		ya.manager_emit("shell", {
 			custom_shell_cmd,


### PR DESCRIPTION
It looks like current `ya.quote` does not have second argument, and removing that fixed the issue for me.

https://yazi-rs.github.io/docs/plugins/utils#ya.quote