### PR TITLE
Change match pattern to work on Windows

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -131,7 +131,7 @@ local function history_prev(history_path)
 end
 
 local function entry(_, job)
-	local shell_env = os.getenv("SHELL"):match(".*/(.*)")
+	local shell_env = os.getenv("SHELL"):match(".*[/\\]([^%.]+)")
 	local shell_value, cmd, custom_shell_cmd = "", "", ""
 
 	local history_path, save_history = state_option("history_path"), state_option("save_history")


### PR DESCRIPTION
I change the match pattern to work with backslash and only match until first `.` so it excludes `.exe` part.

Tested on my Windows machine with two different `SHELL` value:
- `C:\Program Files\PowerShell\7\pwsh.exe`
- `/pwsh`

By the way, this extension depends on the `SHELL` environment variable to work properly. Should we display an error message if `shell_env` is `nil` after the match? Currently, it simply crashes in that case.